### PR TITLE
max-len ignoreComments

### DIFF
--- a/es2015.js
+++ b/es2015.js
@@ -33,7 +33,6 @@ module.exports = {
     'keyword-spacing': 'error',
     'linebreak-style': ['error', 'unix'],
     'lines-around-directive': 'error',
-    'max-len': ['error', 128, { ignoreComments: true }],
     'max-statements-per-line': 'error',
     'new-parens': 'error',
     'no-caller': 'error',

--- a/es2015.js
+++ b/es2015.js
@@ -33,7 +33,7 @@ module.exports = {
     'keyword-spacing': 'error',
     'linebreak-style': ['error', 'unix'],
     'lines-around-directive': 'error',
-    'max-len': ['error', 128],
+    'max-len': ['error', 128, { "ignoreComments": true }],
     'max-statements-per-line': 'error',
     'new-parens': 'error',
     'no-caller': 'error',

--- a/es2015.js
+++ b/es2015.js
@@ -33,7 +33,7 @@ module.exports = {
     'keyword-spacing': 'error',
     'linebreak-style': ['error', 'unix'],
     'lines-around-directive': 'error',
-    'max-len': ['error', 128, { "ignoreComments": true }],
+    'max-len': ['error', 128, { ignoreComments: true }],
     'max-statements-per-line': 'error',
     'new-parens': 'error',
     'no-caller': 'error',


### PR DESCRIPTION
```js
    /**
     * Determines whether two tokens can safely be placed next to each other without merging into a single token
     * @param {Token|string} leftValue The left token. If this is a string, it will be tokenized and the last token will be used.
     * @param {Token|string} rightValue The right token. If this is a string, it will be tokenized and the first token will be used.
     * @returns {boolean} If the tokens cannot be safely placed next to each other, returns `false`. If the tokens can be placed
     * next to each other, behavior is undefined (although it should return `true` in most cases).
     */
```

error: 
```bash
  1261:1  error  Line 1261 exceeds the maximum line length of 128  max-len
  1262:1  error  Line 1262 exceeds the maximum line length of 128  max-len
```